### PR TITLE
hash_to_curve: take AsRef<[u8]> as ciphersuite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pairing"
 
 # Remember to change version string in README.md.
-version = "0.15.0"
+version = "0.16.0"
 authors = [
     "Sean Bowe <ewillbefull@gmail.com>",
     "Jack Grigg <jack@z.cash>",

--- a/src/hash_to_curve.rs
+++ b/src/hash_to_curve.rs
@@ -11,10 +11,10 @@ type CoordT<PtT> = <PtT as CurveProjective>::Base;
 /// Random oracle and injective maps to curve
 pub trait HashToCurve {
     /// Random oracle
-    fn hash_to_curve<B: AsRef<[u8]>>(msg: B, ciphersuite: u8) -> Self;
+    fn hash_to_curve<B: AsRef<[u8]>, C: AsRef<[u8]>>(msg: B, ciphersuite: C) -> Self;
 
     /// Injective encoding
-    fn encode_to_curve<B: AsRef<[u8]>>(msg: B, ciphersuite: u8) -> Self;
+    fn encode_to_curve<B: AsRef<[u8]>, C: AsRef<[u8]>>(msg: B, ciphersuite: C) -> Self;
 }
 
 impl<PtT> HashToCurve for PtT
@@ -22,9 +22,9 @@ where
     PtT: ClearH + IsogenyMap + OSSWUMap,
     CoordT<PtT>: FromRO,
 {
-    fn hash_to_curve<B: AsRef<[u8]>>(msg: B, ciphersuite: u8) -> PtT {
+    fn hash_to_curve<B: AsRef<[u8]>, C: AsRef<[u8]>>(msg: B, ciphersuite: C) -> PtT {
         let mut p = {
-            let h2f = HashToField::<CoordT<PtT>>::new(msg, Some(&[ciphersuite]));
+            let h2f = HashToField::<CoordT<PtT>>::new(msg, Some(ciphersuite.as_ref()));
             let mut tmp = PtT::osswu_map(&h2f.with_ctr(0));
             tmp.add_assign(&PtT::osswu_map(&h2f.with_ctr(1)));
             tmp
@@ -34,9 +34,9 @@ where
         p
     }
 
-    fn encode_to_curve<B: AsRef<[u8]>>(msg: B, ciphersuite: u8) -> PtT {
+    fn encode_to_curve<B: AsRef<[u8]>, C: AsRef<[u8]>>(msg: B, ciphersuite: C) -> PtT {
         let mut p = {
-            let h2f = HashToField::<CoordT<PtT>>::new(msg, Some(&[ciphersuite]));
+            let h2f = HashToField::<CoordT<PtT>>::new(msg, Some(ciphersuite.as_ref()));
             PtT::osswu_map(&h2f.with_ctr(2))
         };
         p.isogeny_map();


### PR DESCRIPTION
This commit also updates the version number to 0.16.0, since this is a breaking change in the HashToCurve trait.