### PR TITLE
Merge veccom to master

### DIFF
--- a/src/bls12_381/ec/mod.rs
+++ b/src/bls12_381/ec/mod.rs
@@ -17,6 +17,7 @@ macro_rules! curve_impl {
             pub(crate) infinity: bool,
         }
 
+        /// # Safety
         pub const unsafe fn transmute_affine(x: $basefield, y: $basefield, i: bool) -> $affine {
             $affine {
                 x: x,
@@ -56,6 +57,8 @@ macro_rules! curve_impl {
             pub(crate) z: $basefield,
         }
 
+        /// placeholder
+        /// # Safety
         pub const unsafe fn transmute_projective(
             x: $basefield,
             y: $basefield,

--- a/src/bls12_381/fq.rs
+++ b/src/bls12_381/fq.rs
@@ -465,6 +465,7 @@ pub const P_M1_OVER2: Fq = Fq(FqRepr([
 #[PrimeFieldGenerator = "2"]
 pub struct Fq(pub(super) FqRepr);
 
+/// # Safety
 pub const unsafe fn transmute(r: FqRepr) -> Fq {
     Fq(r)
 }

--- a/src/bls12_381/fr.rs
+++ b/src/bls12_381/fr.rs
@@ -16,6 +16,7 @@ impl ::std::default::Default for Fr {
     }
 }
 
+/// # Safety
 pub const unsafe fn transmute(r: FrRepr) -> Fr {
     Fr(r)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::many_single_char_names))]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::write_literal))]
+#![cfg_attr(feature = "cargo-clippy", allow(clippy::missing_safety_doc))]
 // Force public structures to implement Debug
 #![deny(missing_debug_implementations)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ pub trait Engine: ScalarEngine {
                 (&(p1.into().prepare()), &(q1.into().prepare())),
                 (&(p2.into().prepare()), &(q2.into().prepare())),
             ]
-            .into_iter(),
+            .iter(),
         ))
         .unwrap()
     }

--- a/src/serdes.rs
+++ b/src/serdes.rs
@@ -324,5 +324,4 @@ mod serdes_test {
         assert_eq!(compressed, true);
         assert_eq!(fr_rand, fr_rand_recover);
     }
-
 }


### PR DESCRIPTION
Merge the veccom branch into master (including Leo's fast computations; excluding `hash_to_fr`, `cast_string_to_curve` etc).
Still need to port the relevant test cases.
This PR will NOT pass linter as of today -- latest rust nightly doesn't support clippy. 