### PR TITLE
HashToField: invoke HKDF on H(msg) rather than msg

### DIFF
--- a/src/bls12_381/fq.rs
+++ b/src/bls12_381/fq.rs
@@ -2324,12 +2324,12 @@ fn test_fq_hash_to_field() {
     let mut hash_iter = HashToField::<Fq>::new("hello world", None);
     let fq_val = hash_iter.next().unwrap();
     let expect = FqRepr([
-        0x605979d293c88efeu64,
-        0x8cce6e2990ca245eu64,
-        0xb216c1419710b3a9u64,
-        0xeb60d0d2d54275a0u64,
-        0x354a68d7ef36672u64,
-        0x5f74a1547366cecu64,
+        0x47137dbe0aab2c73u64,
+        0x203a41a517b34d1cu64,
+        0x55d019e5914e11c1u64,
+        0xc106ddc4af8ffa5du64,
+        0x1ff762c5f1bfd8b4u64,
+        0x19f78b0bb3eba06au64,
     ]);
     assert_eq!(fq_val, Fq::from_repr(expect).unwrap());
 
@@ -2338,12 +2338,12 @@ fn test_fq_hash_to_field() {
 
     let fq_val = hash_iter.next().unwrap();
     let expect = FqRepr([
-        0x21f37a28981adf2au64,
-        0xfcb319a0d42af630u64,
-        0xbfd027f2c55177fbu64,
-        0x66f286dd263e7609u64,
-        0xa09979be2a6ef430u64,
-        0x39b53f6f58a62fdu64,
+        0x1a29a8209c6f3d2fu64,
+        0x4a6be9dbcd5dd3ebu64,
+        0xbe4a8d4259350048u64,
+        0xdf453be6214f7ddcu64,
+        0x699c40affb0d1314u64,
+        0xcfecc5419b505ffu64,
     ]);
     assert_eq!(fq_val, Fq::from_repr(expect).unwrap());
 }

--- a/src/bls12_381/fq2.rs
+++ b/src/bls12_381/fq2.rs
@@ -993,20 +993,20 @@ fn test_fq2_hash_to_field() {
     let mut hash_iter = HashToField::<Fq2>::new("hello world", None);
     let fq2_val = hash_iter.next().unwrap();
     let expect_c0 = FqRepr([
-        0x605979d293c88efeu64,
-        0x8cce6e2990ca245eu64,
-        0xb216c1419710b3a9u64,
-        0xeb60d0d2d54275a0u64,
-        0x354a68d7ef36672u64,
-        0x5f74a1547366cecu64,
+        0x47137dbe0aab2c73u64,
+        0x203a41a517b34d1cu64,
+        0x55d019e5914e11c1u64,
+        0xc106ddc4af8ffa5du64,
+        0x1ff762c5f1bfd8b4u64,
+        0x19f78b0bb3eba06au64,
     ]);
     let expect_c1 = FqRepr([
-        0x5091f4f73bc1b5f8u64,
-        0xe24885242fa3a122u64,
-        0x4b5e051202bcf75du64,
-        0xb78b75eaaaa87832u64,
-        0x35940e11b7f7cb9au64,
-        0x162c4cd4f9023db6u64,
+        0x3cabacb8389463acu64,
+        0x58d6edc60b79a74u64,
+        0xa9281e1d30c69193u64,
+        0x671968378855db46u64,
+        0x873a64d8f4ebc763u64,
+        0xa2bac9b17355499u64,
     ]);
     let expect = Fq2 {
         c0: Fq::from_repr(expect_c0).unwrap(),
@@ -1016,20 +1016,20 @@ fn test_fq2_hash_to_field() {
 
     let fq2_val = hash_iter.next().unwrap();
     let expect_c0 = FqRepr([
-        0x21f37a28981adf2au64,
-        0xfcb319a0d42af630u64,
-        0xbfd027f2c55177fbu64,
-        0x66f286dd263e7609u64,
-        0xa09979be2a6ef430u64,
-        0x39b53f6f58a62fdu64,
+        0x1a29a8209c6f3d2fu64,
+        0x4a6be9dbcd5dd3ebu64,
+        0xbe4a8d4259350048u64,
+        0xdf453be6214f7ddcu64,
+        0x699c40affb0d1314u64,
+        0xcfecc5419b505ffu64,
     ]);
     let expect_c1 = FqRepr([
-        0x5b4a356b86dc3740u64,
-        0xa50eaa39af36389eu64,
-        0x35f2042b81ea5999u64,
-        0x5dd5cde1b8c03f75u64,
-        0x3e2f80c1855be51fu64,
-        0x1827c0f181cac0a1u64,
+        0x7e6f1837dcd928b2u64,
+        0xebccabee6ad6c2c7u64,
+        0xcead509d4cbd55dbu64,
+        0x6e3b8a2cdc185d5bu64,
+        0x6bd81e0e63c25643u64,
+        0x6b62a5a37510870u64,
     ]);
     let expect = Fq2 {
         c0: Fq::from_repr(expect_c0).unwrap(),

--- a/src/hash_to_field.rs
+++ b/src/hash_to_field.rs
@@ -12,7 +12,7 @@ use std::marker::PhantomData;
 /// A struct that handles hashing a message to one or more values of T.
 #[derive(Debug)]
 pub struct HashToField<T> {
-    msg_hashed: GenericArray<u8, <sha2::Sha256 as Digest>::OutputSize>,
+    msg_hashed: GenericArray<u8, <Sha256 as Digest>::OutputSize>,
     ctr: u8,
     phantom: PhantomData<T>,
 }
@@ -20,8 +20,13 @@ pub struct HashToField<T> {
 impl<T: FromRO> HashToField<T> {
     /// Create a new struct given a message and ciphersuite.
     pub fn new<B: AsRef<[u8]>>(msg: B, dst: Option<&[u8]>) -> HashToField<T> {
+        HashToField::from_hash(Sha256::digest(msg.as_ref()), dst)
+    }
+
+    /// Create a new struct given a message already hashed with SHA-256
+    pub fn from_hash(msg_hash: GenericArray<u8, <Sha256 as Digest>::OutputSize>, dst: Option<&[u8]>) -> HashToField<T> {
         HashToField::<T> {
-            msg_hashed: Hkdf::<Sha256>::extract(dst, msg.as_ref()).0,
+            msg_hashed: Hkdf::<Sha256>::extract(dst, msg_hash.as_ref()).0,
             ctr: 0,
             phantom: PhantomData::<T>,
         }


### PR DESCRIPTION
This fixes the hash-to-field impl used by BLS sigs etc to match the forthcoming change in the hash-to-curve spec doc.